### PR TITLE
add a new option: restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Pauses timer.
 ### `timer.resume()`
 Resumes timer.
 
+### `timer.restart()`
+Restarts timer.
+
 ## Events
 
 ### `timer.on('tick', (ms) => {})`
@@ -69,4 +72,4 @@ Gets the current time in ms.
 Gets the total `duration` the timer is running for in ms.
 
 ### `timer.status`
-Gets the current status of the timer as a string: `running`, `paused` or `stopped`.
+Gets the current status of the timer as a string: `running`, `paused`, `stopped` or `restarted`.

--- a/src/tiny-timer.ts
+++ b/src/tiny-timer.ts
@@ -1,6 +1,6 @@
 import mitt, { EventType, Handler } from 'mitt'
 
-type Status = 'running' | 'paused' | 'stopped'
+type Status = 'running' | 'paused' | 'stopped' | 'restarted'
 
 class Timer {
   private _interval: number
@@ -45,6 +45,12 @@ class Timer {
     this._endTime += Date.now() - this._pauseTime
     this._pauseTime = 0
     this._changeStatus('running')
+  }
+
+  public restart () {
+    this._endTime += Date.now() + this._duration
+    this._pauseTime = 0
+    this._changeStatus('restarted')
   }
 
   private _changeStatus (status: Status) {

--- a/test-ts.ts
+++ b/test-ts.ts
@@ -74,6 +74,14 @@ test('pause and resume', (t) => {
   timer.pause()
 })
 
+test('restarted', (t) => {
+  const timer = new Timer({ interval: 10 })
+  timer.start(50)
+  
+  timer.restart()
+  t.equal(timer.status, 'restarted')
+})
+
 test('state transition', (t) => {
   const timer = new Timer({ interval: 10 })
   t.equal(timer.status, 'stopped')

--- a/test.js
+++ b/test.js
@@ -71,6 +71,14 @@ test('pause and resume', function (t) {
   timer.pause()
 })
 
+test('restarted', (t) => {
+  const timer = new Timer({ interval: 10 })
+  timer.start(50)
+
+  timer.restart()
+  t.equal(timer.status, 'restarted')
+})
+
 test('state transition', function (t) {
   const timer = new Timer({ interval: 10 })
   t.equal(timer.status, 'stopped')


### PR DESCRIPTION
The stopwatch can be restarted. 
When the stopwatch has run down, you know that no one has restarted the stopwatch.

I use the stopwatch for monitoring. When the stopwatch runs out, I can trigger an alarm.